### PR TITLE
bump requires-python to satisfy uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0"
 description = "Data Preprocessing for ELM Runs"
 authors = [{ name = "Dapper contributors", email = "dapper@lanl.gov" }]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 license = {file = "license.md"}
 dependencies = [
   "geopandas",


### PR DESCRIPTION
without this, I see:

> jsta@machine: uv sync
Using CPython 3.9.25 interpreter at: /usr/bin/python3
Creating virtual environment at: .venv
  × No solution found when resolving dependencies
  │ for split (markers: python_full_version ==
  │ '3.10.*' and platform_machine == 'ARM64' and
  │ sys_platform == 'win32'):
  ╰─▶ Because the requested Python version
      (>=3.8) does not satisfy Python>=3.11 and
      pandas>=3.0.0 depends on Python>=3.11, we can
      conclude that pandas>=3.0.0 cannot be used.
      And because only the following versions of
      pandas are available:
          pandas<=3.0.0
          pandas==3.0.1
          pandas==3.0.2
          pandas==3.0.3
      and your project depends on pandas>=3, we can
      conclude that your project's requirements are
      unsatisfiable.
      hint: While the active Python version is
      3.9, the resolution failed for other Python
      versions supported by your project. Consider
      limiting your project's supported Python
      versions using `requires-python`.
      hint: The `requires-python` value (>=3.8)
      includes Python versions that are not
      supported by your dependencies (e.g.,
      pandas>=3.0.0 only supports >=3.11). Consider
      using a more restrictive `requires-python`
      value (like >=3.11).
